### PR TITLE
:bug: ensure default layout is used if layout.html does not exist in cwd

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -53,7 +53,12 @@ if (argv.help) {
 
 argv.source = argv.source || argv._[0] || '.'
 argv.build = argv.build || 'build'
-argv.layout = argv.layout || 'layout.html'
+argv.layout = argv.layout
 argv.silent = argv.silent || false
 
-sitedown(argv)
+try {
+  sitedown(argv)
+} catch (e) {
+  console.error(e.message)
+  process.exit(1)
+}

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var md = require('markdown-it')({
 })
 md.use(require('markdown-it-highlightjs'))
 
+var defaultLayout = path.join(__dirname, 'layout.html')
 var encoding = { encoding: 'utf8' }
 
 function noop () {}
@@ -26,10 +27,16 @@ function sitedown (options, callback) {
   options = options || {}
   options.source = options.source || cwp('.')
   options.build = options.build || cwp('build')
-  options.layout = options.layout ? path.resolve(process.cwd(), options.layout) : path.join(__dirname, 'layout.html')
+  options.layout = options.layout ? path.resolve(process.cwd(), options.layout) : defaultLayout
   options.files = []
 
   if (typeof callback === 'undefined') callback = noop
+
+  if (!fs.existsSync(options.layout)) {
+    var error = new Error('layout file not found: ' + options.layout)
+    if (callback === noop) throw error
+    return callback(error)
+  }
 
   readdirp({
     root: options.source,

--- a/test/index.js
+++ b/test/index.js
@@ -95,3 +95,32 @@ test.only('site generation', function (t) {
     })
   }
 })
+
+test('site generation - callback with error if options.layout file does not exist', function (t) {
+  var opts = {
+    source: path.join(__dirname, 'markdown'),
+    build: path.join(__dirname, 'build'),
+    layout: 'nope',
+    silent: true
+  }
+
+  sitedown(opts, function (err) {
+    t.ok(err.message.match('layout file not found'), 'callback with error when layout is not found')
+    t.end()
+  })
+})
+
+test('site generation - throws error if options.layout file does not exist and no callback passed', function (t) {
+  var opts = {
+    source: path.join(__dirname, 'markdown'),
+    build: path.join(__dirname, 'build'),
+    layout: 'nope',
+    silent: true
+  }
+
+  sitedown(opts, function (err) {
+    t.ok(err.message.match('layout file not found'), 'throws an error when layout is not found')
+    t.end()
+  })
+})
+


### PR DESCRIPTION
When running via `bin.js` the layout option is set to `layout.html` but this causes an error if `layout.html` does not exist in the current working directory.

This PR adds a check to see if the file exists and switches back to the default layout if it does not.